### PR TITLE
Fix typo of settings key

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Below you can find an example config file. All the possible parameters are docum
 [on the Elastic site](https://www.elastic.co/guide/en/apm/agent/ruby/current/configuration.html#_options).
 
 ```yaml
-:foreman_supervisory_authoriy:
+:foreman_supervisory_authority:
   server_url: https://elastic-apm.example.com
   secret_token: '12345verysecret'
   service_name: 'foreman'

--- a/config/foreman_supervisory_authority.yaml.example
+++ b/config/foreman_supervisory_authority.yaml.example
@@ -1,4 +1,4 @@
-:foreman_supervisory_authoriy:
+:foreman_supervisory_authority:
   server_url: https://elastic-apm.example.com
   secret_token: '12345verysecret'
   service_name: 'foreman'

--- a/lib/foreman_supervisory_authority/engine.rb
+++ b/lib/foreman_supervisory_authority/engine.rb
@@ -23,7 +23,7 @@ module ForemanSupervisoryAuthority
     config.elastic_apm.current_user_email_method = :mail
     config.elastic_apm.current_user_username_method = :login
 
-    config.elastic_apm.merge!(SETTINGS[:foreman_supervisory_authoriy]) if SETTINGS[:foreman_supervisory_authoriy]
+    config.elastic_apm.merge!(SETTINGS[:foreman_supervisory_authority]) if SETTINGS[:foreman_supervisory_authority]
 
     # Include concerns in this config.to_prepare block
     config.to_prepare do


### PR DESCRIPTION
This seems to be a typo which can cause some confusion because Foreman will no longer start if a user uses the "correct" key.